### PR TITLE
fix: include latin-ext subset

### DIFF
--- a/scss/fonts.scss
+++ b/scss/fonts.scss
@@ -2,14 +2,17 @@
 @use "@fontsource/poppins/scss/mixins" as Poppins;
 
 $weights: $font-weight-light, $font-weight-normal, $font-weight-semibold, $font-weight-bold;
+$subsets: (latin, latin-ext);
 
 @include Inter.faces(
 	$weights: $weights,
+	$subsets: $subsets,
 	$display: fallback,
 	$directory: "./plugins/nodebb-theme-harmony/inter"
 );
 @include Poppins.faces(
-  $weights: $weights,
-  $display: fallback,
-  $directory: "./plugins/nodebb-theme-harmony/poppins"
+	$weights: $weights,
+	$subsets: $subsets,
+	$display: fallback,
+	$directory: "./plugins/nodebb-theme-harmony/poppins"
 );


### PR DESCRIPTION
Currently only latin characters are included with fonts, and everything else is relegated to a fallback, which looks very much off for non-english languages...

`latin-ext` is supported by both Inter and Poppins, which is why I stopped short of adding the remaining subsets Inter supports for now.

Example:

| current | fixed |
| ---- | ----- |
| ![current text with Polish characters in SegoeUI](https://github.com/NodeBB/nodebb-theme-harmony/assets/25460763/0c411d43-ae59-4bdd-9912-f2a46fd90417) | ![fixed text with uniform font](https://github.com/NodeBB/nodebb-theme-harmony/assets/25460763/ba3ad2e4-85b7-4cc7-8993-3348a597d9ab) |