### PR TITLE
Use `rel=me` for links in user profile

### DIFF
--- a/templates/account/profile.tpl
+++ b/templates/account/profile.tpl
@@ -67,7 +67,7 @@
 		<div class="stat">
 			<div class="align-items-center justify-content-center card card-header px-0 py-3 border-0 rounded-1 h-100 gap-2">
 				<span class="stat-label text-xs fw-semibold"><i class="text-muted fa-solid fa-globe"></i> <span>[[user:website]]</span></span>
-				<a class="text-sm text-center text-break w-100 px-2 ff-secondary text-underline text-reset" href="{websiteLink}" rel="nofollow noopener noreferrer me">{websiteName}</a>
+				<a class="text-sm text-center text-break w-100 px-2 ff-secondary text-underline text-reset" href="{websiteLink}" rel="nofollow noreferrer me">{websiteName}</a>
 			</div>
 		</div>
 		{{{ end }}}

--- a/templates/account/profile.tpl
+++ b/templates/account/profile.tpl
@@ -67,7 +67,7 @@
 		<div class="stat">
 			<div class="align-items-center justify-content-center card card-header px-0 py-3 border-0 rounded-1 h-100 gap-2">
 				<span class="stat-label text-xs fw-semibold"><i class="text-muted fa-solid fa-globe"></i> <span>[[user:website]]</span></span>
-				<a class="text-sm text-center text-break w-100 px-2 ff-secondary text-underline text-reset" href="{websiteLink}" rel="nofollow noopener noreferrer">{websiteName}</a>
+				<a class="text-sm text-center text-break w-100 px-2 ff-secondary text-underline text-reset" href="{websiteLink}" rel="nofollow noopener noreferrer me">{websiteName}</a>
 			</div>
 		</div>
 		{{{ end }}}


### PR DESCRIPTION
Implements the first part of NodeBB/NodeBB#11886

Additionally, I removed the redundant `noopener` from the link - AFAIK all browsers that support it, support `noreferrer` implying the same behavior in addition to not passing the `Referer` header (since `noreferrer` is older)

Edit: turns out using both can actually cause some older browsers to NOT respect `noreferrer` (specifically, Firefox between version 33-35): https://github.com/jsx-eslint/eslint-plugin-react/issues/2022#issuecomment-524631866