### PR TITLE
Display category description on category page

### DIFF
--- a/templates/category.tpl
+++ b/templates/category.tpl
@@ -4,6 +4,11 @@
 		{buildCategoryIcon(@value, "40px", "rounded-1 flex-shrink-0")}
 		<h1 class="tracking-tight fs-2 fw-semibold mb-0 text-center">{./name}</h1>
 	</div>
+	{{{ if ./descriptionParsed }}}
+		<div class="description text-muted text-sm w-100">
+			{./descriptionParsed}
+		</div>
+	{{{ end }}}
 	<div class="d-flex flex-wrap gap-2 {{{ if config.theme.centerHeaderElements }}}justify-content-center{{{ end }}}">
 		<span class="badge text-body border border-gray-300 stats text-xs">
 			<span title="{totalTopicCount}" class="fw-bold">{humanReadableNumber(totalTopicCount)}</span>


### PR DESCRIPTION
This will display the description of the category on the category page. I believe this is a good default and probably desired by most users.

Reference: 
[NodeBB community discussion](https://community.nodebb.org/topic/8293/category-header-introduction-text)

<img width="548" alt="Screenshot 2023-10-07 at 10 10 33 AM" src="https://github.com/NodeBB/nodebb-theme-harmony/assets/69390532/22a764aa-1410-4f14-9613-b94cad9741a8">
