### PR TITLE
add openSidebars to harmony theme settings in ACP

### DIFF
--- a/templates/account/theme.tpl
+++ b/templates/account/theme.tpl
@@ -43,6 +43,11 @@
 	</div>
 
 	<div class="form-check mb-3">
+		<input class="form-check-input" type="checkbox" id="openSidebars" name="openSidebars" {{{ if theme.openSidebars }}}checked{{{ end }}}>
+		<label class="form-check-label" for="openSidebars">[[themes/harmony:settings.openSidebars]]</label>
+	</div>
+
+	<div class="form-check mb-3">
 		<input class="form-check-input" type="checkbox" id="chatModals" name="chatModals" {{{ if theme.chatModals }}}checked{{{ end }}}>
 		<label class="form-check-label" for="chatModals">
 			[[themes/harmony:settings.chatModals]]

--- a/templates/admin/plugins/harmony.tpl
+++ b/templates/admin/plugins/harmony.tpl
@@ -35,6 +35,10 @@
 					</div>
 				</div>
 				<div class="form-check form-switch">
+					<input type="checkbox" class="form-check-input" id="openSidebars" name="openSidebars" />
+					<label for="openSidebars" class="form-check-label">[[themes/harmony:settings.openSidebars]]</label>
+				</div>
+				<div class="form-check form-switch">
 					<input type="checkbox" class="form-check-input" id="chatModals" name="chatModals" />
 					<div for="chatModals" class="form-check-label">
 						[[themes/harmony:settings.chatModals]]


### PR DESCRIPTION
The admin should be able to set whether the Navigation Sidebars should be collapsed or not on the initial app load. 


TODO: a translation needs to be added for openSidebars in [Transifex](https://app.transifex.com/nodebb/nodebb/translate/#en_US/themes-harmony/459243410). I am not sure how to do it and I don't think I have the permissions for the same. 

Also, what is the point of this file: templates/account/theme.tpl
Does the form need to be updated there as well? I don't see a difference.


<img width="703" alt="Screenshot 2023-10-13 at 7 00 11 PM" src="https://github.com/NodeBB/nodebb-theme-harmony/assets/69390532/7064bd81-9949-4b72-a8e1-7a3777da5ebe">