### PR TITLE
Display breadcrumbs on topic page

### DIFF
--- a/templates/topic.tpl
+++ b/templates/topic.tpl
@@ -1,4 +1,6 @@
 <!-- IMPORT partials/breadcrumbs-json-ld.tpl -->
+<!-- IMPORT partials/breadcrumbs.tpl -->
+
 {{{ if widgets.header.length }}}
 <div data-widget-area="header">
 	{{{each widgets.header}}}

--- a/templates/topic.tpl
+++ b/templates/topic.tpl
@@ -1,6 +1,5 @@
 <!-- IMPORT partials/breadcrumbs-json-ld.tpl -->
 <!-- IMPORT partials/breadcrumbs.tpl -->
-
 {{{ if widgets.header.length }}}
 <div data-widget-area="header">
 	{{{each widgets.header}}}


### PR DESCRIPTION
I have added breadcrumbs to the topic page. Was there a reason why this was omitted?

We can add it as a harmony theme setting in ACP, if preferred. 