### PR TITLE
fix: only show crosspost button to users who can crosspost

### DIFF
--- a/templates/partials/topic/crosspost.tpl
+++ b/templates/partials/topic/crosspost.tpl
@@ -1,4 +1,4 @@
-{{{ if loggedIn }}}
+{{{ if privileges.topics:crosspost }}}
 <button component="topic/crosspost" title="{{tx("topic:crosspost-topic")}}" class="btn btn-ghost btn-sm ff-secondary d-flex gap-2 align-items-center text-truncate">
 	<i class="fa fa-fw fa-square-arrow-up-right text-primary"></i>
 	<span class="d-none d-md-inline fw-semibold text-truncate text-nowrap">{{tx("topic:thread-tools.crosspost")}}</span>


### PR DESCRIPTION
Theme half of NodeBB/NodeBB#14657.

`partials/topic/crosspost.tpl` renders the button for every logged-in user, but `topics.crossposts.add()` requires `topics:crosspost` on the **destination** category. Users without it see the button, open the modal, pick a category, and only then get `[[error:not-allowed]]`.

The core PR exposes the `topics:crosspost` privilege on the topic page, alongside the other category privileges. This swaps the gate over to it.

```diff
-{{{ if loggedIn }}}
+{{{ if privileges.topics:crosspost }}}
```

**Depends on NodeBB/NodeBB#14657** — without it `privileges.topics:crosspost` is undefined and the button disappears for everyone, so this should only land alongside (or after) the core change.

