### PR TITLE
fix: restore rel=me for website profile links

### DIFF
--- a/templates/account/profile.tpl
+++ b/templates/account/profile.tpl
@@ -78,7 +78,7 @@
 			<div class="align-items-center justify-content-center card card-header p-3 border-0 rounded-1 h-100 gap-2">
 				<span class="stat-label text-xs fw-semibold"><span><i class="text-muted {./icon}"></i> {{tx(./name)}}</span></span>
 				{{{ if (./type == "input-link") }}}
-				<a class="text-center text-break w-100 px-2 ff-secondary text-underline text-reset" href="{./value}" rel="nofollow noreferrer">{./linkValue}</a>
+				<a class="text-center text-break w-100 px-2 ff-secondary text-underline text-reset" href="{./value}" rel="nofollow noreferrer{{{ if (./key == "website") }}} me{{{ end }}}">{./linkValue}</a>
 				{{{ else }}}
 				<span class="text-center text-break {{{ if (./type == "input-number") }}}fs-2{{{else }}}fs-6{{{ end }}} ff-secondary">{./value}</span>
 				{{{ end }}}


### PR DESCRIPTION
## Summary

- restore `rel="me"` for the built-in `website` custom profile field
- keep `nofollow noreferrer` unchanged for every other `input-link` custom field

NodeBB's website field was converted into a default custom profile field, so the earlier XFN behavior from #24 no longer applied to it. Checking the field key preserves that behavior without treating arbitrary links as identity assertions.

## Verification

- `npm run lint`
- rendered the updated condition with Benchpress and verified that `website` receives `nofollow noreferrer me`
- verified that a second arbitrary link still receives only `nofollow noreferrer`
- `git diff --check`

Refs NodeBB/NodeBB#11886
