### PR TITLE
fix: update drafts badge when drafts change in another tab

### DIFF
--- a/public/harmony.js
+++ b/public/harmony.js
@@ -198,6 +198,13 @@ $(document).ready(function () {
 
 			$(window).on('action:composer.drafts.save', updateBadgeCount);
 			$(window).on('action:composer.drafts.remove', updateBadgeCount);
+			// drafts live in localStorage; keep the badge in sync when another tab saves or removes a draft
+			$(window).on('storage', function (ev) {
+				const key = ev.originalEvent && ev.originalEvent.key;
+				if (key === null || key === 'drafts:available') {
+					updateBadgeCount();
+				}
+			});
 			updateBadgeCount();
 		});
 	}


### PR DESCRIPTION
## Problem

The drafts badge in the sidebar (and the bottom bar on mobile) goes stale across tabs. Save or delete a draft in one tab, and every other open tab keeps showing the old count until the page is reloaded.

Notifications don't have this problem because the server pushes \`event:notifications.updateCount\` over socket.io to every connected tab. Drafts, however, live entirely in \`localStorage\` on the client. \`setupDrafts()\` only refreshes the badge on page load and on the composer's \`action:composer.drafts.save\` / \`action:composer.drafts.remove\` jQuery events, which are per-tab.

## Fix

Listen for the \`storage\` event on \`window\`. Browsers fire it in every *other* tab of the same origin whenever \`localStorage\` is written. The badge is refreshed when the \`drafts:available\` list (the key \`drafts.getAvailableCount()\` derives from) changes, or when storage is cleared (\`key === null\`).

Guests are unaffected: their drafts are in \`sessionStorage\`, which is per-tab and does not fire the event. The dropdown list itself needs no change since it is re-rendered on every \`shown.bs.dropdown\`.

## Test

1. Log in, open the forum in two tabs.
2. In tab A, start a new topic/reply and type something so a draft gets saved.
3. Switch to tab B without reloading: the drafts badge now shows the updated count.
4. Delete the draft from the drafts dropdown in tab A; tab B's badge updates/hides.